### PR TITLE
Feat(timeout): Add timeout to Faraday client

### DIFF
--- a/lib/nordigen-ruby.rb
+++ b/lib/nordigen-ruby.rb
@@ -29,7 +29,7 @@ module Nordigen
 
     def request
       # HTTP client request
-      @request ||= Faraday.new do |conn|
+      @request ||= Faraday.new(request: { timeout: 10 }) do |conn|
         conn.url_prefix = BASE_URL
         conn.headers = @@headers
         conn.request :json

--- a/tests/test_institution.rb
+++ b/tests/test_institution.rb
@@ -12,7 +12,7 @@ module Nordigen
       client = NordigenClient.new(secret_id: ENV['SECRET_ID'], secret_key: ENV['SECRET_KEY'])
       client.generate_token
       @institution = InstitutionsApi.new(client)
-      @institution_id = 'REVOLUT_REVOGB21'
+      @institution_id = 'REVOLUT_REVOLT21'
     end
 
     def test_get_institutions


### PR DESCRIPTION
Adds a timeout to the underlying Faraday client. (default is 1 minute, which is quite long: https://github.com/lostisland/faraday/issues/708)